### PR TITLE
add logging for event trigger

### DIFF
--- a/backend/apps/rules/services/action.py
+++ b/backend/apps/rules/services/action.py
@@ -28,21 +28,39 @@ class Action:
             from apps.rules import tasks
 
             getattr(tasks, task_name).delay(event_id)
+            logger.info(
+                "Task enqueued",
+                extra={"context": {"task": task_name, "event_id": event_id}},
+            )
         except Exception:
-            logger.exception(f"Failed to enqueue task: {task_name}")
+            logger.exception(
+                "Failed to enqueue task",
+                extra={"context": {"task": task_name, "event_id": event_id}},
+            )
 
     @staticmethod
     def dispatch_action(rule: Rule, telemetry: Telemetry) -> Event:
         """
         Create Event and dispatch async side-effects.
         """
-        logger.info("Create event on action")
-
         event = Event.objects.create(
             rule=rule,
             timestamp=timezone.now(),
             trigger_telemetry_id=telemetry.id,
             trigger_device_id=telemetry.device_metric.device_id,
+        )
+
+        logger.info(
+            "Event created",
+            extra={
+                "context": {
+                    "event_id": event.id,
+                    "rule_id": rule.id,
+                    "rule_name": rule.name,
+                    "trigger_telemetry_id": telemetry.id,
+                    "trigger_device_id": telemetry.device_metric.device_id,
+                }
+            },
         )
 
         for task_name in Action.TASKS:


### PR DESCRIPTION
## Description
The following acceptance criteria were implemented in #99 #29:
- Event data model/schema
- Event creation on rule match
- Event/state tracking (rule, device, telemetry linkage)
- API examples

Current updates logging of triggered events:
- Event Creation
- Async Task Dispatch Logging (notify_event, deliver_webhook) 
- - 
### Reason for Deferral
Celery tasks are currently stubs / partially implemented.
Full logging will be added when:
- Webhook delivery logic is finalized.
- Notification logic is fully implemented.
- Retry strategy is defined.

Adding detailed logging now would likely require refactoring once final task behavior is established.

## Related Issue
- #86 


